### PR TITLE
Fix frame rotation for text detecting and improve performance

### DIFF
--- a/camerakit-core/src/main/api16/com/wonderkiln/camerakit/Camera1.java
+++ b/camerakit-core/src/main/api16/com/wonderkiln/camerakit/Camera1.java
@@ -158,6 +158,10 @@ public class Camera1 extends CameraImpl {
         this.mDisplayOrientation = displayOrientation;
         this.mDeviceOrientation = deviceOrientation;
 
+        if (mFrameProcessor != null) {
+            mFrameProcessor.setDeviceOrientation(this.mDeviceOrientation);
+        }
+
         synchronized (mCameraLock) {
             if (isCameraOpened()) {
                 try {
@@ -684,7 +688,7 @@ public class Camera1 extends CameraImpl {
             mEventDispatcher.dispatch(new CameraKitEvent(CameraKitEvent.TYPE_CAMERA_OPEN));
 
             if (mTextDetector != null) {
-                mFrameProcessor = new FrameProcessingRunnable(mTextDetector, mPreviewSize, mCamera);
+                mFrameProcessor = new FrameProcessingRunnable(mTextDetector, mPreviewSize, mCamera, mDisplayOrientation);
                 mFrameProcessor.start();
             }
         }


### PR DESCRIPTION
Currently, frame builder has hardcoded value of rotation and text can be detected only in one orientation.

https://github.com/CameraKit/camerakit-android/blob/ea798f2db8b4b31d6dd492563c76350b72ea12a1/camerakit-core/src/main/vision/com/wonderkiln/camerakit/FrameProcessingRunnable.java#L121

Also `Choreographer` skips so many frames. I've replaced thread-lock with period-based frequency