### PR TITLE
Include jpegkit 1.0 dependency for beta 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ To include __CameraKit__ in your project, add the following to your `app` level 
 ```java
 dependencies {
     implementation 'com.camerakit:camerakit:1.0.0-beta3.9'
+    implementation 'com.camerakit:jpegkit:0.1.0'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.61'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:0.24.0'
 }


### PR DESCRIPTION
I can't seem to take photos without this, so it must be needed.