### PR TITLE
Solving problems with android API 16/17

### DIFF
--- a/camerakit/src/main/utils/com/wonderkiln/camerakit/JpegTransformer.java
+++ b/camerakit/src/main/utils/com/wonderkiln/camerakit/JpegTransformer.java
@@ -41,6 +41,7 @@ public class JpegTransformer {
     }
 
     static {
+        System.loadLibrary("yuvOperator");
         System.loadLibrary("jpegTransformer");
     }
 


### PR DESCRIPTION
On Android API 16 and 17 it's necessary Load C++ libraries. In this case, we discovery that this library don't import the values correct, follow this PR to solve this problem.

Issue https://github.com/CameraKit/camerakit-android/issues/477