### PR TITLE
v0.13.5

### DIFF
--- a/camerakit/src/main/utils/com/wonderkiln/camerakit/JpegTransformer.java
+++ b/camerakit/src/main/utils/com/wonderkiln/camerakit/JpegTransformer.java
@@ -41,6 +41,7 @@ public class JpegTransformer {
     }
 
     static {
+        System.loadLibrary("yuvOperator");
         System.loadLibrary("jpegTransformer");
     }
 


### PR DESCRIPTION
## CameraKit v0.13.5
This patch fixes JPEG transformer loading issue when capturing an image on API level 17 and below.

Closes #478 
Closes #477