### PR TITLE
Cameraview setting adjust capture device orientation

### DIFF
--- a/camerakit/src/main/api16/com/wonderkiln/camerakit/Camera1.java
+++ b/camerakit/src/main/api16/com/wonderkiln/camerakit/Camera1.java
@@ -58,6 +58,7 @@ public class Camera1 extends CameraImpl {
     private boolean mRecording;
     private int mDisplayOrientation;
     private int mDeviceOrientation;
+    private boolean mAdjustCaptureForDeviceOrientation;
 
     @Facing
     private int mFacing;
@@ -153,6 +154,11 @@ public class Camera1 extends CameraImpl {
 
     void setDisplayAndDeviceOrientation() {
         setDisplayAndDeviceOrientation(this.mDisplayOrientation, this.mDeviceOrientation);
+    }
+
+    @Override
+    void setAdjustCaptureForDeviceOrientation(boolean adjustCaptureForDeviceOrientation) {
+        mAdjustCaptureForDeviceOrientation = adjustCaptureForDeviceOrientation;
     }
 
     @Override
@@ -744,10 +750,12 @@ public class Camera1 extends CameraImpl {
 
         // Accommodate for any extra device rotation relative to fixed screen orientations
         // (e.g. activity fixed in portrait, but user took photo/video in landscape)
-        if (mCameraInfo.facing == Camera.CameraInfo.CAMERA_FACING_FRONT) {
-            captureRotation = ((captureRotation - (mDisplayOrientation - mDeviceOrientation)) + 360) % 360;
-        } else {  // back-facing camera
-            captureRotation = (captureRotation + (mDisplayOrientation - mDeviceOrientation) + 360) % 360;
+        if(mAdjustCaptureForDeviceOrientation) {
+            if (mCameraInfo.facing == Camera.CameraInfo.CAMERA_FACING_FRONT) {
+                captureRotation = ((captureRotation - (mDisplayOrientation - mDeviceOrientation)) + 360) % 360;
+            } else {  // back-facing camera
+                captureRotation = (captureRotation + (mDisplayOrientation - mDeviceOrientation) + 360) % 360;
+            }
         }
 
         return captureRotation;

--- a/camerakit/src/main/base/com/wonderkiln/camerakit/CameraImpl.java
+++ b/camerakit/src/main/base/com/wonderkiln/camerakit/CameraImpl.java
@@ -21,6 +21,7 @@ abstract class CameraImpl {
     abstract void stop();
 
     abstract void setDisplayAndDeviceOrientation(int displayOrientation, int deviceOrientation);
+    abstract void setAdjustCaptureForDeviceOrientation(boolean adjustCaptureForDeviceOrientation);
 
     abstract void setFacing(@Facing int facing);
     abstract void setFlash(@Flash int flash);

--- a/camerakit/src/main/java/com/wonderkiln/camerakit/CameraKit.java
+++ b/camerakit/src/main/java/com/wonderkiln/camerakit/CameraKit.java
@@ -61,6 +61,7 @@ public class CameraKit {
         static final boolean DEFAULT_CROP_OUTPUT = false;
         static final boolean DEFAULT_DOUBLE_TAP_TO_TOGGLE_FACING = false;
         static final boolean DEFAULT_ADJUST_VIEW_BOUNDS = false;
+        static final boolean DEFAULT_ADJUST_CAPTURE_FOR_DEVICE_ORIENTATION = true;
 
     }
 

--- a/camerakit/src/main/java/com/wonderkiln/camerakit/CameraView.java
+++ b/camerakit/src/main/java/com/wonderkiln/camerakit/CameraView.java
@@ -79,6 +79,7 @@ public class CameraView extends CameraViewLayout {
     private boolean mDoubleTapToToggleFacing;
 
     private boolean mAdjustViewBounds;
+    private boolean mAdjustCaptureForDeviceOrientation;
 
     private DisplayOrientationDetector mDisplayOrientationDetector;
     private CameraImpl mCameraImpl;
@@ -122,6 +123,7 @@ public class CameraView extends CameraViewLayout {
                 mDoubleTapToToggleFacing = a.getBoolean(R.styleable.CameraView_ckDoubleTapToToggleFacing, CameraKit.Defaults.DEFAULT_DOUBLE_TAP_TO_TOGGLE_FACING);
                 mLockVideoAspectRatio = a.getBoolean(R.styleable.CameraView_ckLockVideoAspectRatio, false);
                 mAdjustViewBounds = a.getBoolean(R.styleable.CameraView_android_adjustViewBounds, CameraKit.Defaults.DEFAULT_ADJUST_VIEW_BOUNDS);
+                mAdjustCaptureForDeviceOrientation = a.getBoolean(R.styleable.CameraView_ckAdjustCaptureForDeviceOrientation, CameraKit.Defaults.DEFAULT_ADJUST_CAPTURE_FOR_DEVICE_ORIENTATION);
             } finally {
                 a.recycle();
             }
@@ -151,6 +153,7 @@ public class CameraView extends CameraViewLayout {
         setVideoQuality(mVideoQuality);
         setVideoBitRate(mVideoBitRate);
         setLockVideoAspectRatio(mLockVideoAspectRatio);
+        setAdjustCaptureForDeviceOrientation(mAdjustCaptureForDeviceOrientation);
 
         if (!isInEditMode()) {
             mDisplayOrientationDetector = new DisplayOrientationDetector(context) {
@@ -400,6 +403,11 @@ public class CameraView extends CameraViewLayout {
 
     public void setCropOutput(boolean cropOutput) {
         this.mCropOutput = cropOutput;
+    }
+
+    public void setAdjustCaptureForDeviceOrientation(boolean adjustCaptureForDeviceOrientation) {
+        mAdjustCaptureForDeviceOrientation = adjustCaptureForDeviceOrientation;
+        mCameraImpl.setAdjustCaptureForDeviceOrientation(adjustCaptureForDeviceOrientation);
     }
 
     @Facing

--- a/camerakit/src/main/res/values/attrs.xml
+++ b/camerakit/src/main/res/values/attrs.xml
@@ -61,6 +61,8 @@
 
         <attr name="android:adjustViewBounds" />
 
+        <attr name="ckAdjustCaptureForDeviceOrientation" format="boolean"/>
+
     </declare-styleable>
 
 </resources>

--- a/demo/src/main/java/com/wonderkiln/camerakit/demo/MainActivity.java
+++ b/demo/src/main/java/com/wonderkiln/camerakit/demo/MainActivity.java
@@ -44,6 +44,7 @@ public class MainActivity extends AppCompatActivity {
 
     private int cameraMethod = CameraKit.Constants.METHOD_STANDARD;
     private boolean cropOutput = false;
+    private boolean adjustCaptureForDeviceOrientation = true;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -177,6 +178,7 @@ public class MainActivity extends AppCompatActivity {
         final List<CameraSetting> options = new ArrayList<>();
         options.add(captureMethodSetting);
         options.add(cropSetting);
+        options.add(ignoreDeviceOrientationSetting);
 
         drawerAdapter = new ArrayAdapter<CameraSetting>(this, R.layout.drawer_list_item, R.id.text1, options) {
             @Override
@@ -268,4 +270,19 @@ public class MainActivity extends AppCompatActivity {
         }
     };
 
+    private CameraSetting ignoreDeviceOrientationSetting = new CameraSetting() {
+        @Override
+        String getTitle() { return "ckAdjustCaptureForDeviceOrientation"; }
+
+        @Override
+        String getValue() {
+            return adjustCaptureForDeviceOrientation ? "true" : "false";
+        }
+
+        @Override
+        void toggle() {
+            adjustCaptureForDeviceOrientation = !adjustCaptureForDeviceOrientation;
+            camera.setAdjustCaptureForDeviceOrientation(adjustCaptureForDeviceOrientation);
+        }
+    };
 }


### PR DESCRIPTION
@austinkettner I ended up doing this in my fork.  Again, thought it might be useful for someone somewhere. Just adds a simple flag to control whether or not the output image/video should be adjusted to account for physical device orientation when the UI is locked into a specific orientation.