### PR TITLE
Fix NullPointerException when getting camera preview resolution

### DIFF
--- a/camerakit/src/main/api16/com/wonderkiln/camerakit/Camera1.java
+++ b/camerakit/src/main/api16/com/wonderkiln/camerakit/Camera1.java
@@ -588,7 +588,7 @@ public class Camera1 extends CameraImpl {
     Size getPreviewResolution() {
         Size cameraPreviewResolution = getCameraPreviewResolution();
         boolean invertPreviewSizes = (mCameraInfo.orientation + mDeviceOrientation) % 180 == 90;
-        if (invertPreviewSizes) {
+        if (invertPreviewSizes && cameraPreviewResolution != null) {
             return new Size(cameraPreviewResolution.getHeight(), cameraPreviewResolution.getWidth());
         }
         return cameraPreviewResolution;


### PR DESCRIPTION
Found this crash on v0.13.6.
This PR fixed the exception when the device is trying the perform view onMeasure() but the camera is not opened yet.
So the getCameraPreviewResolution() method will return `null` (which is fine because the CameraView will adjust later), however, if we also want to invert PreviewSizes, the NullException comes up.

The solution is simply adding the null check.

Logcat:
java.lang.NullPointerException: Attempt to invoke virtual method ‘int com.wonderkiln.camerakit.Size.getHeight()’ on a null object reference
       at com.wonderkiln.camerakit.Camera1.getPreviewResolution(Camera1.java:599)
       at com.wonderkiln.camerakit.CameraView.getPreviewSize(CameraView.java:518)
       at com.wonderkiln.camerakit.CameraView.onMeasure(CameraView.java:197)