### PR TITLE
Issue 577: if passive focus then change capture state to waiting non precapture

### DIFF
--- a/camerakit/src/main/java/com/camerakit/api/camera2/Camera2.kt
+++ b/camerakit/src/main/java/com/camerakit/api/camera2/Camera2.kt
@@ -263,7 +263,9 @@ class Camera2(eventsDelegate: CameraEvents, context: Context) :
                     val aeState = result.get(CaptureResult.CONTROL_AE_STATE)
                     if (aeState == null ||
                             aeState == CaptureResult.CONTROL_AE_STATE_PRECAPTURE ||
-                            aeState == CaptureRequest.CONTROL_AE_STATE_FLASH_REQUIRED) {
+                            aeState == CaptureRequest.CONTROL_AE_STATE_FLASH_REQUIRED ||
+                            aeState == CaptureRequest.CONTROL_AF_STATE_PASSIVE_FOCUSED
+                    ) {
                         captureState = STATE_WAITING_NON_PRECAPTURE
                     }
                 }


### PR DESCRIPTION
This commit should fix the issue in #577  and possibly #533 and #467
The Samsung A3's camera was stuck in a 'passive focused' state which was not being caught in the 'state waiting lock'.

This now catches this camera state and will proceed to capture the image