### PR TITLE
Bugs in native code

### DIFF
--- a/camerakit/src/main/utils/com/wonderkiln/camerakit/JpegTransformer.java
+++ b/camerakit/src/main/utils/com/wonderkiln/camerakit/JpegTransformer.java
@@ -13,31 +13,42 @@ public class JpegTransformer {
     }
 
     public byte[] getJpeg() {
+        if (mHandler == null) return null;
         return jniCommit(mHandler);
     }
 
     public int getWidth() {
+        if (mHandler == null) return 0;
         return jniGetWidth(mHandler);
     }
 
     public int getHeight() {
+        if (mHandler == null) return 0;
         return jniGetHeight(mHandler);
     }
 
     public void rotate(int degrees) {
-        jniRotate(mHandler, degrees);
+        if (mHandler != null) {
+            jniRotate(mHandler, degrees);
+        }
     }
 
     public void flipHorizontal() {
-        jniFlipHorizontal(mHandler);
+        if (mHandler != null) {
+            jniFlipHorizontal(mHandler);
+        }
     }
 
     public void flipVertical() {
-        jniFlipVertical(mHandler);
+        if (mHandler != null) {
+            jniFlipVertical(mHandler);
+        }
     }
 
     public void crop(Rect crop) {
-        jniCrop(mHandler, crop.left, crop.top, crop.width(), crop.height());
+        if (mHandler != null) {
+            jniCrop(mHandler, crop.left, crop.top, crop.width(), crop.height());
+        }
     }
 
     static {

--- a/camerakit/src/main/utils/com/wonderkiln/camerakit/YuvOperator.java
+++ b/camerakit/src/main/utils/com/wonderkiln/camerakit/YuvOperator.java
@@ -13,6 +13,7 @@ public class YuvOperator {
     }
 
     public YuvOperator(byte[] yuv, int width, int height) {
+        if (width*height != yuv.length) return;
         storeYuvData(yuv, width, height);
         this.width = width;
         this.height = height;

--- a/camerakit/src/main/utils/com/wonderkiln/camerakit/YuvOperator.java
+++ b/camerakit/src/main/utils/com/wonderkiln/camerakit/YuvOperator.java
@@ -32,6 +32,7 @@ public class YuvOperator {
     }
 
     public byte[] getYuvData() {
+        if (handler == null) return null;
         byte[] yuv = jniGetYuvData(handler);
         freeYuvData();
         return yuv;


### PR DESCRIPTION
This fixes three bugs in the native code of JpegTransformer and YuvOperator, preventing null pointer dereferences and OOB read.